### PR TITLE
IComponentAs: Pivot

### DIFF
--- a/packages/office-ui-fabric-react/src/components/Pivot/Pivot.tsx
+++ b/packages/office-ui-fabric-react/src/components/Pivot/Pivot.tsx
@@ -18,6 +18,8 @@ import { PivotLinkSize } from './Pivot.types';
 import { Icon } from '../../Icon';
 import * as stylesImport from './Pivot.scss';
 const styles: any = stylesImport;
+//remove for prod
+import { getElementType, getElementAttributes } from './PivotItem';
 
 /**
  *  Usage:
@@ -285,30 +287,4 @@ export class Pivot extends BaseComponent<IPivotProps, IPivotState> {
       }
     }
   }
-}
-
-export function getElementType<P>(
-  as: string | IComponentAs<P> | undefined,
-  defaultElement?: string
-): IComponentAs<P> | string {
-
-  if (as) return as;
-
-  if (defaultElement) {
-    return defaultElement;
-  }
-
-  return 'div';
-}
-
-export function getElementAttributes<P extends IBaseProps>(
-  as: string | IComponentAs<P> | undefined,
-  props: P
-): object | undefined {
-
-  if (typeof as === 'function') {
-    return props;
-  }
-
-  return props.with;
 }

--- a/packages/office-ui-fabric-react/src/components/Pivot/Pivot.tsx
+++ b/packages/office-ui-fabric-react/src/components/Pivot/Pivot.tsx
@@ -1,10 +1,12 @@
 import * as React from 'react';
 import {
+  IBaseProps,
   BaseComponent,
   KeyCodes,
   css,
   getId,
-  autobind
+  autobind,
+  IComponentAs
 } from '../../Utilities';
 import { CommandButton } from '../../Button';
 import { IPivotProps } from './Pivot.types';
@@ -91,11 +93,20 @@ export class Pivot extends BaseComponent<IPivotProps, IPivotState> {
   }
 
   public render() {
+    // const ElementType = this.props.as || 'div';
+    // console.log(Pivot);
+    // const ElementType = getElementType<IPivotProps>(Pivot, this.props, 'div');
+    const ElementType = getElementType<IPivotProps>(this.props.as, 'div');
+    // const ElementAttributes = this.props.with;
+    const ElementAttributes = getElementAttributes<IPivotProps>(this.props.as, this.props)
     return (
-      <div>
+      <ElementType { ...ElementAttributes }>
         { this._renderPivotLinks() }
         { this._renderPivotItem() }
-      </div>
+      </ElementType>
+      // <span>
+      //   <ElementType />
+      // </span>
     );
   }
 
@@ -282,3 +293,61 @@ export class Pivot extends BaseComponent<IPivotProps, IPivotState> {
     }
   }
 }
+
+export function getElementType<P>(
+  as: string | IComponentAs<P> | undefined,
+  defaultElement?: string
+): IComponentAs<P> | string {
+
+  if (as) return as;
+
+  if (defaultElement) {
+    return defaultElement;
+  }
+
+  return 'div';
+}
+
+export function getElementAttributes<P extends IBaseProps>(
+  as: string | IComponentAs<P> | undefined,
+  props: P
+): object | undefined {
+
+  // console.log(typeof as);
+
+  // if (as === undefined || typeof as === 'string') {
+  //   return props.with;
+  // }
+
+  if (typeof as === 'function') {
+    return props;
+  }
+
+  return props.with;
+}
+
+// export function getElementType<P extends IBaseProps>(
+//   Component: React.ComponentClass,
+//   props: P,
+//   defaultElement?: string
+// ): IComponentAs<P> | string {
+//   const { defaultProps = {} } = Component;
+//   // const { as } = props;
+
+//   if (props.as) return props.as;
+
+//   if (defaultElement) {
+//     return defaultElement;
+//   }
+
+//   // ----------------------------------------
+//   // infer anchor links
+
+//   // if (props.href) return 'a'
+
+//   // ----------------------------------------
+//   // use defaultProp or 'div'
+
+//   // return defaultProps.as || 'div'
+//   return 'div';
+// }

--- a/packages/office-ui-fabric-react/src/components/Pivot/Pivot.tsx
+++ b/packages/office-ui-fabric-react/src/components/Pivot/Pivot.tsx
@@ -93,20 +93,13 @@ export class Pivot extends BaseComponent<IPivotProps, IPivotState> {
   }
 
   public render() {
-    // const ElementType = this.props.as || 'div';
-    // console.log(Pivot);
-    // const ElementType = getElementType<IPivotProps>(Pivot, this.props, 'div');
     const ElementType = getElementType<IPivotProps>(this.props.as, 'div');
-    // const ElementAttributes = this.props.with;
     const ElementAttributes = getElementAttributes<IPivotProps>(this.props.as, this.props)
     return (
       <ElementType { ...ElementAttributes }>
         { this._renderPivotLinks() }
         { this._renderPivotItem() }
       </ElementType>
-      // <span>
-      //   <ElementType />
-      // </span>
     );
   }
 
@@ -313,41 +306,9 @@ export function getElementAttributes<P extends IBaseProps>(
   props: P
 ): object | undefined {
 
-  // console.log(typeof as);
-
-  // if (as === undefined || typeof as === 'string') {
-  //   return props.with;
-  // }
-
   if (typeof as === 'function') {
     return props;
   }
 
   return props.with;
 }
-
-// export function getElementType<P extends IBaseProps>(
-//   Component: React.ComponentClass,
-//   props: P,
-//   defaultElement?: string
-// ): IComponentAs<P> | string {
-//   const { defaultProps = {} } = Component;
-//   // const { as } = props;
-
-//   if (props.as) return props.as;
-
-//   if (defaultElement) {
-//     return defaultElement;
-//   }
-
-//   // ----------------------------------------
-//   // infer anchor links
-
-//   // if (props.href) return 'a'
-
-//   // ----------------------------------------
-//   // use defaultProp or 'div'
-
-//   // return defaultProps.as || 'div'
-//   return 'div';
-// }

--- a/packages/office-ui-fabric-react/src/components/Pivot/Pivot.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Pivot/Pivot.types.ts
@@ -1,7 +1,11 @@
 import * as React from 'react';
 
-import { Pivot } from './Pivot';
+import { Pivot, IPivotState } from './Pivot';
 import { PivotItem } from './PivotItem';
+import { IComponentAs } from '../../Utilities';
+
+
+// export type IComponentAsTest<T> = React.ComponentClass<T>;
 
 export interface IPivot {
 
@@ -13,6 +17,16 @@ export interface IPivotProps extends React.Props<Pivot> {
    * the public methods and properties of the component.
    */
   componentRef?: (component: IPivot) => void;
+
+  /**
+   * Render component as another component or HTML element
+   */
+  as?: string | IComponentAs<IPivotProps, IPivotState>;
+
+  /**
+   * Render component element with these attributes
+   */
+  with?: any;
 
   /**
    * The index of the pivot item initially selected.

--- a/packages/office-ui-fabric-react/src/components/Pivot/Pivot.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Pivot/Pivot.types.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { Pivot, IPivotState } from './Pivot';
+import { Pivot } from './Pivot';
 import { PivotItem } from './PivotItem';
 import { IComponentAs } from '../../Utilities';
 
@@ -21,7 +21,7 @@ export interface IPivotProps extends React.Props<Pivot> {
   /**
    * Render component as another component or HTML element
    */
-  as?: string | IComponentAs<IPivotProps, IPivotState>;
+  as?: string | IComponentAs<IPivotProps>;
 
   /**
    * Render component element with these attributes

--- a/packages/office-ui-fabric-react/src/components/Pivot/PivotItem.tsx
+++ b/packages/office-ui-fabric-react/src/components/Pivot/PivotItem.tsx
@@ -1,20 +1,53 @@
 import * as React from 'react';
 import {
+  // @remove for prod
+  IBaseProps,
   BaseComponent,
   getNativeProps,
-  divProperties
+  divProperties,
+  // @remove for prod
+  IComponentAs
 } from '../../Utilities';
 import { IPivotItemProps } from './PivotItem.types';
 
 export class PivotItem extends BaseComponent<IPivotItemProps, {}> {
 
   public render() {
+    const ElementType = getElementType<IPivotItemProps>(this.props.as, 'div');
+    const ElementAttributes = getElementAttributes<IPivotItemProps>(this.props.as, this.props)
     return (
-      <div
+      <ElementType
+        { ...ElementAttributes }
         { ...getNativeProps(this.props, divProperties) }
       >
         { this.props.children }
-      </div>
+      </ElementType>
     );
   }
+}
+
+export function getElementType<P>(
+  as: string | IComponentAs<P> | undefined,
+  defaultElement?: string
+): IComponentAs<P> | string {
+
+  if (as) return as;
+
+  if (defaultElement) {
+    return defaultElement;
+  }
+
+  return 'div';
+}
+
+export function getElementAttributes<P extends IBaseProps>(
+  as: string | IComponentAs<P> | undefined,
+  props: P
+): object | undefined {
+
+  if (typeof as === 'function') {
+    return props;
+  }
+
+  return props.with;
 }

--- a/packages/office-ui-fabric-react/src/components/Pivot/PivotItem.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Pivot/PivotItem.types.ts
@@ -1,11 +1,24 @@
 import * as React from 'react';
-import { IRenderFunction } from '../../Utilities';
+import {
+  IRenderFunction,
+  IComponentAs
+} from '../../Utilities';
 
 export interface IPivotItemProps extends React.HTMLAttributes<HTMLDivElement> {
   /**
    * Gets the component ref.
    */
   componentRef?: () => void;
+
+  /**
+   * Render component as another component or HTML element
+   */
+  as?: string | IComponentAs<IPivotItemProps>;
+
+  /**
+   * Render component element with these attributes
+   */
+  with?: object;
 
   /**
    * The text displayed of each pivot link.

--- a/packages/office-ui-fabric-react/src/components/Pivot/examples/Pivot.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Pivot/examples/Pivot.Basic.Example.tsx
@@ -3,10 +3,21 @@ import { Label } from 'office-ui-fabric-react/lib/Label';
 import { BaseComponent } from '../../../Utilities';
 import { ActionButton } from '../../Button';
 import { IPivotProps } from '../Pivot.types';
+import { IPivotItemProps } from '../PivotItem.types';
 // import { IPivotItemProps } from '../PivotItem.types';
 import { Pivot, PivotItem, IPivotState } from 'office-ui-fabric-react/lib/Pivot';
 import * as exampleStylesImport from '../../../common/_exampleStyles.scss';
 const exampleStyles: any = exampleStylesImport;
+
+export class MyCustomPivotItem extends BaseComponent<IPivotItemProps, {}> {
+  public render() {
+    return (
+      <aside { ...this.props.with }>
+        <Label>Special Pivot</Label>
+      </aside>
+    );
+  }
+}
 
 export class PivotBasicExample extends React.Component<any, any> {
   public render() {
@@ -22,10 +33,18 @@ export class PivotBasicExample extends React.Component<any, any> {
           <PivotItem linkText='My Files'>
             <Label className={ exampleStyles.exampleLabel }>Pivot #1</Label>
           </PivotItem>
-          <PivotItem linkText='Recent'>
+          <PivotItem
+            as={ MyCustomPivotItem }
+            with={ { 'data-name': 'third' } }
+            linkText='Recent'
+          >
             <Label>Pivot #2</Label>
           </PivotItem>
-          <PivotItem linkText='Shared with me'>
+          <PivotItem
+            as={ 'span' }
+            with={ { 'data-name': 'third' } }
+            linkText='Shared with me'
+          >
             <Label>Pivot #3</Label>
           </PivotItem>
         </Pivot>

--- a/packages/office-ui-fabric-react/src/components/Pivot/examples/Pivot.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Pivot/examples/Pivot.Basic.Example.tsx
@@ -1,6 +1,10 @@
 import * as React from 'react';
 import { Label } from 'office-ui-fabric-react/lib/Label';
-import { Pivot, PivotItem } from 'office-ui-fabric-react/lib/Pivot';
+import { BaseComponent } from '../../../Utilities';
+import { ActionButton } from '../../Button';
+import { IPivotProps } from '../Pivot.types';
+// import { IPivotItemProps } from '../PivotItem.types';
+import { Pivot, PivotItem, IPivotState } from 'office-ui-fabric-react/lib/Pivot';
 import * as exampleStylesImport from '../../../common/_exampleStyles.scss';
 const exampleStyles: any = exampleStylesImport;
 
@@ -8,7 +12,13 @@ export class PivotBasicExample extends React.Component<any, any> {
   public render() {
     return (
       <div>
-        <Pivot>
+        <Pivot
+          as={ 'article' }
+          with={ {
+            'data-order': 12,
+            'data-title': 'ted'
+          } }
+        >
           <PivotItem linkText='My Files'>
             <Label className={ exampleStyles.exampleLabel }>Pivot #1</Label>
           </PivotItem>

--- a/packages/office-ui-fabric-react/src/components/Pivot/examples/Pivot.IconCount.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Pivot/examples/Pivot.IconCount.Example.tsx
@@ -14,10 +14,8 @@ import { BaseComponent } from '../../../Utilities';
 
 export class MyCustomPivot extends BaseComponent<IPivotProps, IPivotState> {
   public render() {
-    const atts = this.props.with;
     return (
-      // @todo fix props passing
-      <nav { ...atts }>
+      <nav { ...this.props.with }>
         <p>Hello Ted!</p>
       </nav>
     );

--- a/packages/office-ui-fabric-react/src/components/Pivot/examples/Pivot.IconCount.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Pivot/examples/Pivot.IconCount.Example.tsx
@@ -1,17 +1,39 @@
 import * as React from 'react';
 import { Label } from 'office-ui-fabric-react/lib/Label';
 import { Icon } from 'office-ui-fabric-react/lib/Icon';
-import {
-  PivotItem,
-  IPivotItemProps,
-  Pivot
-} from 'office-ui-fabric-react/lib/Pivot';
+// import {
+//   PivotItem,
+//   IPivotItemProps,
+//   Pivot
+// } from 'office-ui-fabric-react/lib/Pivot';
+import { Pivot, IPivotState } from '../Pivot';
+import { PivotItem } from '../PivotItem';
+import { IPivotProps } from '../Pivot.types';
+import { IPivotItemProps } from '../PivotItem.types';
+import { BaseComponent } from '../../../Utilities';
 
+export class MyCustomPivot extends BaseComponent<IPivotProps, IPivotState> {
+  public render() {
+    const atts = this.props.with;
+    return (
+      // @todo fix props passing
+      <nav { ...atts }>
+        <p>Hello Ted!</p>
+      </nav>
+    );
+  }
+}
 export class PivotIconCountExample extends React.Component<any, any> {
   public render() {
     return (
       <div>
-        <Pivot>
+        <Pivot
+          as={ MyCustomPivot }
+          with={ {
+            'data-whatever': 'boom',
+            'tis-illegal': 'to do this'
+          } }
+        >
           <PivotItem linkText='My Files' itemCount={ 42 } itemIcon='Emoji2'>
             <Label>Pivot #1</Label>
           </PivotItem>

--- a/packages/utilities/src/BaseComponent.ts
+++ b/packages/utilities/src/BaseComponent.ts
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { Async } from './Async';
 import { EventGroup } from './EventGroup';
 import { IDisposable } from './IDisposable';
+import { IComponentAs } from './IComponentAs';
 import { warnDeprecations, warnMutuallyExclusive, warnConditionallyRequiredProps, ISettingsMap } from './warn';
 
 /**
@@ -12,6 +13,8 @@ import { warnDeprecations, warnMutuallyExclusive, warnConditionallyRequiredProps
 // tslint:disable-next-line:no-any
 export interface IBaseProps<T = any> {
   componentRef?: (ref: T | null) => (void | T);
+  as?: string | IComponentAs<IBaseProps>;
+  with?: object;
 }
 
 /**

--- a/packages/utilities/src/IComponentAs.ts
+++ b/packages/utilities/src/IComponentAs.ts
@@ -1,0 +1,7 @@
+/**
+ * Render function interface for providing overrideable render callbacks.
+ *
+ * @public
+ */
+// export type IComponentAs<P> = string | ((props?: P) => JSX.Element);
+export type IComponentAs<T> = React.StatelessComponent<T> | React.ComponentClass<T>;

--- a/packages/utilities/src/index.ts
+++ b/packages/utilities/src/index.ts
@@ -9,6 +9,7 @@ export * from './EventGroup';
 export * from './FabricPerformance';
 export * from './GlobalSettings';
 export * from './IClassNames';
+export * from './IComponentAs';
 export * from './IDisposable';
 export * from './IPoint';
 export * from './IRectangle';


### PR DESCRIPTION
Based on the 'as' prop used in Semantic UI, I was testing out a way to customize the tags and attributes of components for fabric in a scalable way that can be applied across the board

## 'as' prop
This prop sets the tag element of the outermost element in the component using a string - can be expanded to a component or function. Has a fallback to the tag it was in the first place.

## 'with' prop
Contains native attributes applied to the same element as the 'as' prop (outer most element). This does not require the 'as' prop to be set

## 'xxxxAs' and 'xxxxWith' props
In many components we will want to target a child element that we want to affect, like an 'input' inside a div container with a label.  In this case I tested replacing the 'span' tag in Dropdown, so it is called 'spanAs' and works the same as the main 'as' and 'with' props.